### PR TITLE
Add configurable port ranges and database path

### DIFF
--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -14,14 +15,15 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
-	dbName := "file:./local.db"
+	dbPath := flag.String("db", "", "Database file path (default: ./local.db)")
+	flag.Parse()
 
-	repo := db.NewRepository(ctx, dbName)
+	ctx := context.Background()
+	repo := db.NewRepository(ctx, *dbPath)
 	defer repo.Close()
 
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: %s <command> [args...]\n", os.Args[0])
+	if flag.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: %s [-db path] <command> [args...]\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "Commands:\n")
 		fmt.Fprintf(os.Stderr, "  list              List all VPN configs\n")
 		fmt.Fprintf(os.Stderr, "  add <file_path>   Add VPN config from file\n")
@@ -29,17 +31,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	command := os.Args[1]
+	command := flag.Arg(0)
 
 	switch command {
 	case "list":
 		listVPNConfigs(repo)
 	case "add":
-		if len(os.Args) < 3 {
+		if flag.NArg() < 2 {
 			fmt.Fprintf(os.Stderr, "Usage: %s add <file_path>\n", os.Args[0])
 			os.Exit(1)
 		}
-		filePath := os.Args[2]
+		filePath := flag.Arg(1)
 		addVPNConfig(repo, filePath)
 	case "revalidate":
 		revalidateVPNConfigs(repo)

--- a/cmd/scrappah/main.go
+++ b/cmd/scrappah/main.go
@@ -21,7 +21,7 @@ type App struct {
 	Repo *db.Repository
 }
 
-func NewApp() *App {
+func NewApp(dbPath string) *App {
 	s := make(chan os.Signal, 1)
 
 	signal.Notify(s, syscall.SIGINT, syscall.SIGQUIT)
@@ -32,8 +32,7 @@ func NewApp() *App {
 		cancel()
 	}()
 
-	dbName := "file:./local.db"
-	repo := db.NewRepository(ctx, dbName)
+	repo := db.NewRepository(ctx, dbPath)
 
 	return &App{
 		Ctx:  ctx,
@@ -95,9 +94,10 @@ func (app *App) LoadVPNConfigs(startingPort, count int) []*wireproxy.Configurati
 func main() {
 	startingPort := flag.Int("starting-port", 8001, "Starting port for SOCKS5 proxies")
 	count := flag.Int("count", 5, "Number of VPN configurations to load and create proxies for")
+	dbPath := flag.String("db", "", "Database file path (default: ./local.db)")
 	flag.Parse()
 
-	app := NewApp()
+	app := NewApp(*dbPath)
 	defer app.Close()
 
 	configs := app.LoadVPNConfigs(*startingPort, *count)

--- a/cmd/scrappah/main.go
+++ b/cmd/scrappah/main.go
@@ -49,20 +49,16 @@ func (app *App) Close() error {
 func (app *App) LoadVPNConfigs(startingPort, count int) []*wireproxy.Configuration {
 	vpnConfigs := app.Repo.GetVPNConfigs()
 
-	// Validation: fail if DB is empty
 	if len(vpnConfigs) == 0 {
 		fmt.Println("Error: Database is empty. Please add VPN configurations before starting.")
 		os.Exit(1)
 	}
 
-	// Validation: fail if DB has fewer configs than requested count
 	if len(vpnConfigs) < count {
-		fmt.Printf("Error: Database contains %d configs but %d were requested. Please add more configurations or reduce count.\n", len(vpnConfigs), count)
-		os.Exit(1)
+		fmt.Printf("Warning: Database contains %d configs but %d were requested. Using all %d available configs.\n", len(vpnConfigs), count, len(vpnConfigs))
+	} else {
+		vpnConfigs = vpnConfigs[:count]
 	}
-
-	// Only process the requested count of configurations
-	vpnConfigs = vpnConfigs[:count]
 
 	validCount := 0
 	invalidCount := 0
@@ -97,7 +93,6 @@ func (app *App) LoadVPNConfigs(startingPort, count int) []*wireproxy.Configurati
 }
 
 func main() {
-	// Parse command line flags
 	startingPort := flag.Int("starting-port", 8001, "Starting port for SOCKS5 proxies")
 	count := flag.Int("count", 5, "Number of VPN configurations to load and create proxies for")
 	flag.Parse()

--- a/cmd/scrappah/main.go
+++ b/cmd/scrappah/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -45,13 +46,28 @@ func (app *App) Close() error {
 	return err
 }
 
-func (app *App) LoadVPNConfigs() []*wireproxy.Configuration {
+func (app *App) LoadVPNConfigs(startingPort, count int) []*wireproxy.Configuration {
 	vpnConfigs := app.Repo.GetVPNConfigs()
+
+	// Validation: fail if DB is empty
+	if len(vpnConfigs) == 0 {
+		fmt.Println("Error: Database is empty. Please add VPN configurations before starting.")
+		os.Exit(1)
+	}
+
+	// Validation: fail if DB has fewer configs than requested count
+	if len(vpnConfigs) < count {
+		fmt.Printf("Error: Database contains %d configs but %d were requested. Please add more configurations or reduce count.\n", len(vpnConfigs), count)
+		os.Exit(1)
+	}
+
+	// Only process the requested count of configurations
+	vpnConfigs = vpnConfigs[:count]
 
 	validCount := 0
 	invalidCount := 0
 
-	startingPort := 8001
+	currentPort := startingPort
 
 	var builder strings.Builder
 
@@ -59,10 +75,10 @@ func (app *App) LoadVPNConfigs() []*wireproxy.Configuration {
 	for _, vpnConfig := range vpnConfigs {
 		builder.WriteString(string(vpnConfig.ConfigContent))
 		builder.WriteString(
-			"\n\n[Socks5]\nBindAddress = 0.0.0.0:" + strconv.Itoa(startingPort) + "\n",
+			"\n\n[Socks5]\nBindAddress = 0.0.0.0:" + strconv.Itoa(currentPort) + "\n",
 		)
 		vpnConfig.ConfigContent = []byte(builder.String())
-		startingPort++
+		currentPort++
 		builder.Reset()
 
 		validConfig, err := pkg.ValidateVPNConfig(vpnConfig)
@@ -81,10 +97,15 @@ func (app *App) LoadVPNConfigs() []*wireproxy.Configuration {
 }
 
 func main() {
+	// Parse command line flags
+	startingPort := flag.Int("starting-port", 8001, "Starting port for SOCKS5 proxies")
+	count := flag.Int("count", 5, "Number of VPN configurations to load and create proxies for")
+	flag.Parse()
+
 	app := NewApp()
 	defer app.Close()
 
-	configs := app.LoadVPNConfigs()
+	configs := app.LoadVPNConfigs(*startingPort, *count)
 
 	for _, config := range configs {
 		if config == nil {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 
 	_ "github.com/tursodatabase/go-libsql"
 )
@@ -14,8 +15,16 @@ type Repository struct {
 	ctx context.Context
 }
 
-func NewRepository(ctx context.Context, dbName string) *Repository {
-	db, err := sql.Open("libsql", dbName)
+func NewRepository(ctx context.Context, dbPath string) *Repository {
+	if dbPath == "" {
+		dbPath = getDefaultDBPath()
+	}
+	
+	if !strings.HasPrefix(dbPath, "file:") {
+		dbPath = "file:" + dbPath
+	}
+	
+	db, err := sql.Open("libsql", dbPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open db %s", err)
 		os.Exit(1)
@@ -24,12 +33,24 @@ func NewRepository(ctx context.Context, dbName string) *Repository {
 	return &Repository{db: db, ctx: ctx}
 }
 
+func getDefaultDBPath() string {
+	return "./local.db"
+}
+
 func (r *Repository) Close() error {
 	return r.db.Close()
 }
 
-func GetDB(dbName string) *sql.DB {
-	db, err := sql.Open("libsql", dbName)
+func GetDB(dbPath string) *sql.DB {
+	if dbPath == "" {
+		dbPath = getDefaultDBPath()
+	}
+	
+	if !strings.HasPrefix(dbPath, "file:") {
+		dbPath = "file:" + dbPath
+	}
+	
+	db, err := sql.Open("libsql", dbPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open db %s", err)
 		os.Exit(1)


### PR DESCRIPTION
Adds command-line flags to configure proxy allocation:
- `--starting-port`: Set starting port for SOCKS5 proxies (default: 8001)  
- `--count`: Limit number of VPN configs to load (default: 5)
- `--db`: Set custom database file path (default: ./local.db)

Validates database is not empty before starting proxies.

Closes #1